### PR TITLE
fix protocol URL validation and normalize handler input

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4373,16 +4373,29 @@ ${contentParts.join('')}
   }
 
   private isValidUrl(text: string): boolean {
+    const normalized = text.trim();
+    if (!normalized) return false;
+
     try {
-      const url = new URL(text);
+      const url = new URL(normalized);
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return false;
+      }
+
+      const hostname = url.hostname.toLowerCase();
       const supportedDomains = [
         'facebook.com',
         'fb.com',
+        'fb.watch',
         'linkedin.com',
+        'lnkd.in',
         'instagram.com',
+        'instagr.am',
         'tiktok.com',
         'x.com',
         'twitter.com',
+        't.co',
+        'xcancel.com',
         'threads.net',
         'threads.com',
         'youtube.com',
@@ -4392,10 +4405,25 @@ ${contentParts.join('')}
         'pinterest.com',
         'pin.it',
         'substack.com',
-        'tumblr.com'
+        'tumblr.com',
+        'bsky.app',
+        'medium.com',
+        'velog.io',
+        'blog.naver.com',
+        'cafe.naver.com',
+        'comic.naver.com',
+        'brunch.co.kr',
+        'webtoons.com'
       ];
 
-      return supportedDomains.some(domain => url.hostname.includes(domain));
+      const isKnownDomain = supportedDomains.some(
+        domain => hostname === domain || hostname.endsWith(`.${domain}`)
+      );
+
+      // Mastodon allows custom instance domains: https://<instance>/@<user>/<id>
+      const isMastodonLikePost = /^https?:\/\/[^\s/]+\/@[A-Za-z0-9_@.-]+\/\d+/i.test(normalized);
+
+      return isKnownDomain || isMastodonLikePost;
     } catch {
       return false;
     }
@@ -4450,7 +4478,7 @@ ${contentParts.join('')}
       }
 
       // Handle archive URL (existing behavior)
-      const url = params.url;
+      const url = params.url?.trim();
 
       if (!url) {
         new Notice('No URL provided');


### PR DESCRIPTION
## 요약
`obsidian://social-archive` 프로토콜로 들어오는 URL 검증을 강화하고, 입력 URL 정규화(`trim`)를 추가했습니다.

## 변경 사항
- 프로토콜 핸들러 입력 URL을 `trim()` 후 검증/사용
- `http/https` 프로토콜만 허용
- 도메인 검증을 기존 `includes` 방식에서 아래로 변경
  - `hostname === domain || hostname.endsWith('.' + domain)`
- 실제 사용 케이스를 반영해 지원 도메인 목록 보강
- 인증 토큰/threads 콜백 흐름은 기존 동작 유지

## 변경 이유
기존 `hostname.includes(domain)` 방식은 `facebook.com.evil.com` 같은 오탐 허용 가능성이 있었고, 비HTTP URL/변칙 입력 처리도 약했습니다.

## 검증
사용자 실환경 수동 테스트:
- `https://x.com/...` → 모달 오픈
- `   https://x.com/...   ` → 모달 오픈(정규화 확인)
- `https://facebook.com.evil.com/...` → 차단(모달 미오픈)
- `ftp://x.com/...` → 차단(모달 미오픈)