### PR TITLE
feat: 원커맨드 소셜 아카이브 런처 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,37 @@ Social Archiver uses server infrastructure to fetch content through web scraping
 - Search by content
 - Create your own posts with the + button
 
+### 4. Optional: One-command launcher (Desktop)
+
+If you want to archive from terminal with one command, use the launcher script:
+
+```bash
+npm run archive:social -- --url "https://x.com/jack/status/20"
+```
+
+What it does:
+- Reads your Obsidian `obsidian.json`
+- Finds vaults with `social-archiver` plugin installed
+- Selects vault automatically when only one is available
+- On macOS, shows a GUI picker when multiple vaults are available
+- Opens `obsidian://social-archive?...` with selected vault and URL
+
+Useful options:
+
+```bash
+# list vaults with Social Archiver installed
+npm run archive:social -- --list
+
+# pick vault by name (works on all OS)
+npm run archive:social -- --vault "MyVault" --url "https://x.com/jack/status/20"
+
+# override obsidian.json location
+npm run archive:social -- --config "/path/to/obsidian.json" --url "https://x.com/jack/status/20"
+
+# print URI without opening Obsidian
+npm run archive:social -- --url "https://x.com/jack/status/20" --dry-run
+```
+
 ## Example Output
 
 Archived posts look like this:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:source": "npm run sync:shared && vite build --mode source",
     "verify:release": "node scripts/verify-release-metadata.mjs",
     "check:css-source": "node scripts/check-css-source.mjs",
+    "archive:social": "node scripts/archive-social.mjs",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",

--- a/scripts/archive-social.mjs
+++ b/scripts/archive-social.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const PLUGIN_ID = 'social-archiver';
+
+function printUsage() {
+  console.log(`Usage:
+  node scripts/archive-social.mjs --url <social-url> [--vault <vault-name>] [--config <obsidian.json path>] [--dry-run]
+  npm run archive:social -- --url <social-url> [--vault <vault-name>] [--config <obsidian.json path>] [--dry-run]
+
+Options:
+  --url <url>       URL to archive (or pass as first positional argument)
+  --vault <name>    Vault name (folder name). If omitted, launcher auto-selects.
+  --config <path>   Path to obsidian.json
+  --list            List vaults with Social Archiver installed and exit
+  --dry-run         Print URI only (do not open Obsidian)
+  --help            Show this help
+
+Environment:
+  OBSIDIAN_CONFIG_PATH   Override obsidian.json path
+`);
+}
+
+function parseArgs(argv) {
+  const args = {
+    url: '',
+    vault: '',
+    config: '',
+    list: false,
+    dryRun: false,
+    help: false,
+  };
+
+  const positionals = [];
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+
+    if (token === '--help' || token === '-h') {
+      args.help = true;
+      continue;
+    }
+    if (token === '--list') {
+      args.list = true;
+      continue;
+    }
+    if (token === '--dry-run') {
+      args.dryRun = true;
+      continue;
+    }
+    if (token === '--url') {
+      i += 1;
+      args.url = argv[i] || '';
+      continue;
+    }
+    if (token.startsWith('--url=')) {
+      args.url = token.slice('--url='.length);
+      continue;
+    }
+    if (token === '--vault') {
+      i += 1;
+      args.vault = argv[i] || '';
+      continue;
+    }
+    if (token.startsWith('--vault=')) {
+      args.vault = token.slice('--vault='.length);
+      continue;
+    }
+    if (token === '--config') {
+      i += 1;
+      args.config = argv[i] || '';
+      continue;
+    }
+    if (token.startsWith('--config=')) {
+      args.config = token.slice('--config='.length);
+      continue;
+    }
+    if (token.startsWith('-')) {
+      throw new Error(`Unknown option: ${token}`);
+    }
+
+    positionals.push(token);
+  }
+
+  if (!args.url && positionals.length > 0) {
+    args.url = positionals[0];
+  }
+
+  args.url = args.url.trim();
+  args.vault = args.vault.trim();
+  args.config = args.config.trim();
+
+  return args;
+}
+
+function resolveDefaultConfigCandidates() {
+  const home = os.homedir();
+
+  if (process.platform === 'darwin') {
+    return [path.join(home, 'Library', 'Application Support', 'obsidian', 'obsidian.json')];
+  }
+
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || '';
+    return [
+      path.join(appData, 'obsidian', 'obsidian.json'),
+      path.join(appData, 'Obsidian', 'obsidian.json'),
+    ];
+  }
+
+  const xdg = process.env.XDG_CONFIG_HOME;
+  const candidates = [];
+  if (xdg) {
+    candidates.push(path.join(xdg, 'obsidian', 'obsidian.json'));
+  }
+  candidates.push(path.join(home, '.config', 'obsidian', 'obsidian.json'));
+  return candidates;
+}
+
+function resolveConfigPath(cliConfigPath) {
+  if (cliConfigPath) {
+    const abs = path.resolve(cliConfigPath);
+    if (!fs.existsSync(abs)) {
+      throw new Error(`obsidian.json not found: ${abs}`);
+    }
+    return abs;
+  }
+
+  const envPath = process.env.OBSIDIAN_CONFIG_PATH;
+  if (envPath) {
+    const abs = path.resolve(envPath);
+    if (!fs.existsSync(abs)) {
+      throw new Error(`OBSIDIAN_CONFIG_PATH does not exist: ${abs}`);
+    }
+    return abs;
+  }
+
+  const candidates = resolveDefaultConfigCandidates();
+  const found = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!found) {
+    throw new Error(
+      `Could not find obsidian.json in default locations. Checked:\n- ${candidates.join('\n- ')}`
+    );
+  }
+  return found;
+}
+
+function loadVaults(configPath) {
+  const raw = fs.readFileSync(configPath, 'utf8');
+  const data = JSON.parse(raw);
+  const vaultMap = data?.vaults;
+
+  if (!vaultMap || typeof vaultMap !== 'object') {
+    throw new Error(`Invalid obsidian.json format: missing vaults object (${configPath})`);
+  }
+
+  const vaults = [];
+  for (const value of Object.values(vaultMap)) {
+    if (!value || typeof value !== 'object') continue;
+    if (typeof value.path !== 'string' || !value.path) continue;
+
+    const vaultPath = value.path;
+    const vaultName = path.basename(vaultPath);
+    vaults.push({ name: vaultName, path: vaultPath });
+  }
+
+  return vaults;
+}
+
+function hasSocialArchiver(vaultPath) {
+  const manifestPath = path.join(vaultPath, '.obsidian', 'plugins', PLUGIN_ID, 'manifest.json');
+  return fs.existsSync(manifestPath);
+}
+
+function chooseVaultMac(vaultNames) {
+  const escaped = vaultNames.map((name) => `"${name.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`);
+  const script = [
+    `set vaults to {${escaped.join(', ')}}`,
+    'set selected to choose from list vaults with title "Social Archiver" with prompt "Select vault" default items {item 1 of vaults} without multiple selections allowed',
+    'if selected is false then return ""',
+    'return item 1 of selected',
+  ];
+
+  const result = spawnSync('osascript', script.flatMap((line) => ['-e', line]), {
+    encoding: 'utf8',
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`Vault picker failed: ${result.stderr || result.stdout || 'unknown error'}`);
+  }
+
+  const selected = (result.stdout || '').trim();
+  return selected || '';
+}
+
+function findVaultByName(vaults, wanted) {
+  const exact = vaults.find((vault) => vault.name === wanted);
+  if (exact) return exact;
+
+  const lower = wanted.toLowerCase();
+  return vaults.find((vault) => vault.name.toLowerCase() === lower) || null;
+}
+
+function selectVault(vaults, requestedVaultName) {
+  if (vaults.length === 0) {
+    throw new Error('No vault found with Social Archiver installed.');
+  }
+
+  const duplicateNames = new Set();
+  const seen = new Set();
+  for (const vault of vaults) {
+    if (seen.has(vault.name)) duplicateNames.add(vault.name);
+    seen.add(vault.name);
+  }
+  if (duplicateNames.size > 0) {
+    throw new Error(
+      `Duplicate vault names detected: ${Array.from(duplicateNames).join(', ')}. Please use unique vault names.`
+    );
+  }
+
+  if (requestedVaultName) {
+    const match = findVaultByName(vaults, requestedVaultName);
+    if (!match) {
+      throw new Error(`Vault not found: ${requestedVaultName}`);
+    }
+    return match;
+  }
+
+  if (vaults.length === 1) {
+    return vaults[0];
+  }
+
+  if (process.platform === 'darwin') {
+    const selectedName = chooseVaultMac(vaults.map((vault) => vault.name));
+    if (!selectedName) {
+      throw new Error('Vault selection cancelled.');
+    }
+
+    const match = findVaultByName(vaults, selectedName);
+    if (!match) {
+      throw new Error(`Selected vault not found: ${selectedName}`);
+    }
+
+    return match;
+  }
+
+  const lines = vaults.map((vault) => `- ${vault.name} (${vault.path})`).join('\n');
+  throw new Error(`Multiple vaults found. Re-run with --vault.\n${lines}`);
+}
+
+function buildObsidianUri(vaultName, url) {
+  const params = new URLSearchParams({
+    vault: vaultName,
+    url,
+  });
+  return `obsidian://social-archive?${params.toString()}`;
+}
+
+function openUri(uri) {
+  let result;
+
+  if (process.platform === 'darwin') {
+    result = spawnSync('open', [uri], { stdio: 'ignore' });
+  } else if (process.platform === 'win32') {
+    result = spawnSync('cmd', ['/c', 'start', '', uri], {
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+  } else {
+    result = spawnSync('xdg-open', [uri], { stdio: 'ignore' });
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`Failed to open URI: ${uri}`);
+  }
+}
+
+function main() {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+
+    if (args.help) {
+      printUsage();
+      return;
+    }
+
+    const configPath = resolveConfigPath(args.config);
+    const allVaults = loadVaults(configPath);
+    const supportedVaults = allVaults.filter((vault) => hasSocialArchiver(vault.path));
+
+    if (args.list) {
+      if (supportedVaults.length === 0) {
+        console.log('No vault with Social Archiver installed.');
+        return;
+      }
+
+      for (const vault of supportedVaults) {
+        console.log(`${vault.name}\t${vault.path}`);
+      }
+      return;
+    }
+
+    if (!args.url) {
+      throw new Error('Missing URL. Use --url <social-url>.');
+    }
+
+    const selectedVault = selectVault(supportedVaults, args.vault);
+    const uri = buildObsidianUri(selectedVault.name, args.url);
+
+    if (args.dryRun) {
+      console.log(uri);
+      return;
+    }
+
+    openUri(uri);
+    console.log(`Opened Social Archiver for vault: ${selectedVault.name}`);
+  } catch (error) {
+    console.error(`[archive-social] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## 요약
터미널에서 URL 한 번만 입력하면 Social Archiver를 실행할 수 있는 원커맨드 런처를 추가했습니다.

## 변경 사항
- `scripts/archive-social.mjs` 추가
- `package.json`에 실행 스크립트 추가
  - `npm run archive:social -- --url "<URL>"`
- README에 사용법/검증 방법 추가

## 동작 방식
- Obsidian `obsidian.json`에서 Vault 목록을 읽음
- `social-archiver` 플러그인이 설치된 Vault만 필터링
- 단일 Vault면 자동 선택
- 다중 Vault + macOS면 GUI 선택(`osascript`)
- 비macOS 다중 Vault면 `--vault` 지정 유도
- `--config`, `OBSIDIAN_CONFIG_PATH`, `--list`, `--dry-run` 지원

## 검증
실환경 + 로컬 검증:
- `npm run archive:social -- --list` → 설치된 Vault 목록 출력
- `npm run archive:social -- --url "https://x.com/jack/status/20"` → 모달 오픈 확인
- `npm run archive:social -- --vault "ObsidianVault" --url "https://x.com/jack/status/20" --dry-run` → 예상 URI 출력 확인

## 참고
- 프로젝트 루트가 아닌 디렉터리에서 실행하면 `Missing script`가 발생할 수 있어, 리포 루트 실행 기준으로 안내를 추가했습니다.
- 개인 로컬 절대경로는 커밋 파일에 포함하지 않았습니다.